### PR TITLE
update 05-systick

### DIFF
--- a/05-systick/05-systick.ino
+++ b/05-systick/05-systick.ino
@@ -83,7 +83,9 @@ void setupSystick() {
 }
 
 // the systick event is an ISR attached to Timer 2
-ISR(TIMER2_COMPA_vect) {
+// ISR_NOBLOCK flag is required so that other interrupt routines 
+// such as the encoder ISR run correctly
+ISR(TIMER2_COMPA_vect, ISR_NOBLOCK) {
   updateBatteryVolts();
   updateFunctionSwitch();
 }


### PR DESCRIPTION
05-systick modified by adding ISR_NOBLOCK flag when running systick ISR. This stops systick blocking other interrupts such as an encoder ISR, which causes lost encoder counts. Comment added explaining this.